### PR TITLE
Fix Windows mention in environment table

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,7 +76,7 @@ This is the gap this series attempts to fill. It won't teach about a language, i
 	</tr>
 
 	<tr>
-		<td>Platform</td>
+		<td>Windows</td>
 		<td>LE.EXE</td>
 		<td>COFF</td>
 		<td>library.dll</td>


### PR DESCRIPTION
Just spotted this tiny mistake while reading the intro 🙂 