### PR TITLE
Minor corrections in cpp.php

### DIFF
--- a/cpp.php
+++ b/cpp.php
@@ -194,7 +194,7 @@ int fibonacci(int n) {
 <p> Adding the definition allows the compiler to work in one pass.</p>
 
 <pre>
-<b>$</b> clang -c bad_fibonacci.c // It worked
+<b>$</b> clang -c good_fibonacci.c // It worked
 </pre>
 
 
@@ -893,7 +893,7 @@ const char* getName() {
 
 
 int getLength(const char* string) {
-  returb strlen(string);
+  return strlen(string);
 } 
 </pre>
     </td>    
@@ -977,7 +977,7 @@ const char* getName() {
 
 
 int getLength(const char* string) {
-  returb strlen(string);
+  return strlen(string);
 } 
 </pre>
     </td>    
@@ -1066,7 +1066,7 @@ const char* getName() {
 
 
 int getLength(const char* string) {
-  returb strlen(string);
+  return strlen(string);
 } 
 </pre>
     </td>    


### PR DESCRIPTION
Updates for a couple of typos I noticed on this page:

- Update working fibonacci clang invocation to reference `good_fibonacci.c`
- replace `returb` with `return` in `b.c` examples

I don't have a good setup atm for pulling and validating these changes locally.  They were authored with the GitHub edit feature.  Feel free to ignore, edit, or merge as desired.  