### PR TITLE
Fix fibonacci typo in cpp.php

### DIFF
--- a/cpp.php
+++ b/cpp.php
@@ -187,7 +187,7 @@ int fibonacci(int n) {
 int fibonacci(int n) {
   if (n <= 1)
     return n;
-  return fib(n - 1) + fib(n - 2);
+  return fibonacci(n - 1) + fibonacci(n - 2);
 }</pre>
 
 


### PR DESCRIPTION
This was a small typo in the fibonacci example.