### PR TITLE
Peek inside the right file

### DIFF
--- a/ld.php
+++ b/ld.php
@@ -58,7 +58,7 @@ information for a processes' program image. Relocation entries are these data.
 <img style="border:none;" width=100% src="illu/elf.svg"/>
 
 
-<p>Let's compile <code>hello.c</code> and peek inside <code>hello.o</code>. </p>
+<p>Let's compile <code>hello.c</code> and peek inside <code>a.out</code>. </p>
 
 <pre>// hello.c
 


### PR DESCRIPTION
At least I think this is what it's supposed to say, given that we only inspect the executable instead of the object file. Because the `a.out` is kind of a random name, maybe rewriting it to "and peek inside the result" or "peek inside the executable" would be the better phrasing.