### PR TITLE
cpp.php: fixed mix-up of definitions/declarations terms

### DIFF
--- a/cpp.php
+++ b/cpp.php
@@ -196,7 +196,7 @@ int fibonacci(int n) {
 }</pre>
 
 
-<p> Adding the definition allows the compiler to work in one pass.</p>
+<p>Adding the declaration allows the compiler to work in one pass.</p>
 
 <pre>
 <b>$</b> clang -c good_fibonacci.c // It worked
@@ -219,7 +219,7 @@ int <span class="b">function2</span>(int x) {
   return 2;
 }</pre>
 
-<p>The solution is to adopt a convention where definitions are put in header files and the declaration in the source files. This way, programmers are free to organize their source code as they please.</p>
+<p>The solution is to adopt a convention where declarations are put in header files and the definitions in the source files. This way, programmers are free to organize their source code as they please.</p>
 
 
 <table style="width: 100%;">


### PR DESCRIPTION
I think they were swapped around. I've fixed them.