### PR TITLE
driver.php: updated gcc -v example

### DIFF
--- a/driver.php
+++ b/driver.php
@@ -203,14 +203,12 @@ ld -o a.out hello.o <span class="r">foo bar</span>
 </p>
 <pre>
 <b>$</b> gcc -v hello.c
-COLLECT_GCC_OPTIONS=...
- as -v -EL -mabi=lp64 -o /tmp/ccUkKMFH.o /tmp/ccCKUy4c.s
-COMPILER_PATH==...
-COLLECT_GCC_OPTIONS=...
- /usr/lib/gcc/aarch64-linux-gnu/11/collect2 /tmp/ccIPliNQ.o
+ cc1 hello.c -o /tmp/ccCKUy4c.s
+ as -o /tmp/ccUkKMFH.o /tmp/ccCKUy4c.s
+ collect2 /tmp/ccUkKMFH.o
 </pre>
 <p>
-It is a lot harder to read but we can still make out that an assembler step <code>as</code> took place, followed by a linking step via <code>collect2</code>. The call to the compiler via flag <code>-cc1</code> however is not featured.
+It is a lot harder to read but we can still make out that a compiler step <code>cc1</code> took place, followed by an assembler step <code>as</code>, followed by a linking step via <code>collect2</code>.
 </p>
 </div>
 


### PR DESCRIPTION
The original example omitted the important `cc1` step, which was probably an oversight. It also had different temporary filenames between the executions, also an oversight.

This commit here tries to make the output more faithful (all three steps are visible), while redacting a lot of extra fluff from the output. In fact, we can dynamically filter it using this command:

    gcc -v hello.c 2>&1 | grep '^ [^ ].* '

That will output just the lines starting with a single space, and that contain at least another space somewhere. That's enough to extract the three execution lines from the noisy output. They still have countless parameters in them, which need to be cleaned up manually.

This commit obsoletes the previous pull request
https://github.com/fabiensanglard/dc/pull/16

You can see from the comments on that PR that both `clang` and `gcc` have similarly noisy outputs, and thus both were cleaned up for the article purposes (e.g. removed absolute paths, removed countless parameters, removed environment variables, …)