### PR TITLE
driver.php: source filename consistency

### DIFF
--- a/driver.php
+++ b/driver.php
@@ -219,8 +219,8 @@ Let's take a look at what happens when a project is made of multiple C files.
 
 <pre><b>$</b> clang -v <span class="r">hello</span>.c <span class="b">foo</span>.c <span class="g">bar</span>.c
 clang -cc1 <span class="r">hello</span>.c -o <span class="r">hello</span>.o     // Compile
-clang -cc1 <span class="b">foo</span>.c -o <span class="b">foo</span>.o         // Compile
-clang -cc1 <span class="g">bar</span>.c -o <span class="g">bar</span>.o         // Compile
+clang -cc1 <span class="b">foo</span>.cpp -o <span class="b">foo</span>.o       // Compile
+clang -cc1 <span class="g">bar</span>.m -o <span class="g">bar</span>.o         // Compile
 
 ld -o a.out hello.o foo.o bar.o    // Link
 </pre>


### PR DESCRIPTION
Fixes #17.

Trivia: to actually generate `.o` object files, we need the `-emit-obj` parameter. So I actually had to run this on the terminal:

    clang -cc1 -emit-obj hello.c -o hello.o
    clang -cc1 -emit-obj foo.cpp -o foo.o
    clang -cc1 -emit-obj bar.m -o bar.o
    ld -o a.out hello.o foo.o bar.o

But since this is an *output* from `-v`, it doesn't need to run manually, and thus we can omit this parameter.