### PR TITLE
cc.php: Added second missing `time ./a.out`

### DIFF
--- a/cc.php
+++ b/cc.php
@@ -1081,6 +1081,7 @@ real	0m2.112s
 user	0m2.107s
 sys	0m0.004s
 <b>$</b> clang <span class="b">-O3</span> <span class="r">-flto</span> -c hello.c -o hello.o
+<b>$</b> time ./a.out
 
 real	<span class="b">0m0.002s</span>
 user	0m0.000s


### PR DESCRIPTION
Follow-up of #21.

Answering your comment:

> While I agree commit https://github.com/fabiensanglard/dc/pull/1 was necessary, I think this was done in https://github.com/fabiensanglard/dc/commit/47fe001ce3274e26fe13226265beef3512fccdef.

Well, that commit added the line to the `gcc` example, but the `clang` example was still missing it. This PR addresses the clang case.