### PR TITLE
Add `int` type

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@ I blame this experience on the lack of literature on the topic. Most language bo
 
 <pre>#include &lt;stdio.h&gt;
 
-main()
+int main()
 {
     printf("hello, world\n");
 } </pre>


### PR DESCRIPTION
The example no longer compiled with Clang 18.1.3 that is available in Ubuntu:

```
$ clang -o hello hello.c
hello.c:3:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    3 | main()
      | ^
      | int
1 error generated.
```