### PR TITLE
Escape chars in C++ template examples

### DIFF
--- a/cc.php
+++ b/cc.php
@@ -500,7 +500,7 @@ int main() {
 #include "template.h"
 
 const char* foo() {
-  Name<const char*> name;
+  Name&lt;const char*&gt; name;
   return name.get();
 }
 
@@ -516,7 +516,7 @@ const char* foo() {
 #include "template.h"
 
 const char* bar() {
-  Name<const char*> name;
+  Name&lt;const char*&gt; name;
   return name.get();
 }
 


### PR DESCRIPTION
Browsers incorrectly parse the angle brackets (< >) in the C++ template example as HTML tags, which caused the example code to render incorrectly (e.g., Name<const char*> appeared as Name name;). This commit fixes the display issue by escaping the special characters to their HTML entities (&lt; and &gt;). Example:

**Not sure if this change works. Please make sure first**

<img width="1319" height="574" alt="image" src="https://github.com/user-attachments/assets/e43928fe-3680-47d3-8e90-d0a598d8a897" />
